### PR TITLE
Fix EndDate null reference

### DIFF
--- a/src/TvMaze.Api.Client/Models/Season.cs
+++ b/src/TvMaze.Api.Client/Models/Season.cs
@@ -17,7 +17,7 @@ namespace TvMaze.Api.Client.Models
 
         public string PremiereDate { get; set; }
 
-        public DateTime EndDate { get; set; }
+        public DateTime? EndDate { get; set; }
 
         public Network Network { get; set; }
 


### PR DESCRIPTION
Season `EndDate` can be null if the season is still airing.