### PR TITLE
Mark Episode.Number as nullable, as it is null for specials

### DIFF
--- a/src/TvMaze.Api.Client.Integration.Tests/EpisodesEndpointIntegrationTests.cs
+++ b/src/TvMaze.Api.Client.Integration.Tests/EpisodesEndpointIntegrationTests.cs
@@ -14,12 +14,11 @@ namespace TvMaze.Api.Client.Integration.Tests
             _tvMazeClient = new TvMazeClient();
         }
 
-        [Fact]
-        public async void GetEpisodeByIdAsync_ValidParameter_Success()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(13961)]
+        public async void GetEpisodeByIdAsync_ValidParameter_Success(int episodeId)
         {
-            // arrange
-            const int episodeId = 1;
-
             // act
             var response = await _tvMazeClient.Episodes.GetEpisodeMainInformationAsync(episodeId);
 

--- a/src/TvMaze.Api.Client/Models/Episode.cs
+++ b/src/TvMaze.Api.Client/Models/Episode.cs
@@ -13,7 +13,7 @@ namespace TvMaze.Api.Client.Models
 
         public int Season { get; set; }
 
-        public int Number { get; set; }
+        public int? Number { get; set; }
 
         [JsonProperty("airdate")]
         public string AirDate { get; set; }


### PR DESCRIPTION
Currently all endpoints that can return an Episode object will fail, if the response contains a special, as their number property is null. This should be reflected in the client