### PR TITLE
Add episode types

### DIFF
--- a/src/TvMaze.Api.Client.Integration.Tests/EpisodesEndpointIntegrationTests.cs
+++ b/src/TvMaze.Api.Client.Integration.Tests/EpisodesEndpointIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using TvMaze.Api.Client.Models;
 using Xunit;
 
 namespace TvMaze.Api.Client.Integration.Tests
@@ -15,15 +16,17 @@ namespace TvMaze.Api.Client.Integration.Tests
         }
 
         [Theory]
-        [InlineData(1)]
-        [InlineData(13961)]
-        public async void GetEpisodeByIdAsync_ValidParameter_Success(int episodeId)
+        [InlineData(1, EpisodeType.Regular)]
+        [InlineData(13961, EpisodeType.SignificantSpecial)]
+        [InlineData(13960, EpisodeType.InsignificantSpecial)]
+        public async void GetEpisodeByIdAsync_ValidParameter_Success(int episodeId, EpisodeType expectedType)
         {
             // act
             var response = await _tvMazeClient.Episodes.GetEpisodeMainInformationAsync(episodeId);
 
             // assert
             response.Should().NotBeNull();
+            response.Type.Should().BeEquivalentTo(expectedType);
         }
 
         [Fact]

--- a/src/TvMaze.Api.Client/Models/Episode.cs
+++ b/src/TvMaze.Api.Client/Models/Episode.cs
@@ -7,6 +7,8 @@ namespace TvMaze.Api.Client.Models
     {
         public int Id { get; set; }
 
+        public EpisodeType Type { get; set; }
+
         public string Url { get; set; }
 
         public string Name { get; set; }

--- a/src/TvMaze.Api.Client/Models/EpisodeType.cs
+++ b/src/TvMaze.Api.Client/Models/EpisodeType.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace TvMaze.Api.Client.Models
+{
+    public enum EpisodeType
+    {
+        Regular,
+        [EnumMember(Value = "significant_special")]
+        SignificantSpecial,
+        [EnumMember(Value = "insignificant_special")]
+        InsignificantSpecial
+    }
+}


### PR DESCRIPTION
Episode Objects have a type property, which allows it to differentiate between regular episodes and two kinds of specials.
I got the possible values from the API changelog (https://www.tvmaze.com/threads/4/api-changelog?page=2) because I could not find any other official place where they were documented.