### PR TITLE
Improve unsuccessfull response handling

### DIFF
--- a/src/TvMaze.Api.Client.Integration.Tests/EpisodesEndpointIntegrationTests.cs
+++ b/src/TvMaze.Api.Client.Integration.Tests/EpisodesEndpointIntegrationTests.cs
@@ -30,6 +30,19 @@ namespace TvMaze.Api.Client.Integration.Tests
         }
 
         [Fact]
+        public async void GetEpisodeByIdAsync_ValidParameter_NotFound()
+        {
+            // arrange
+            const int episodeId = int.MaxValue;
+
+            // act
+            var response = await _tvMazeClient.Episodes.GetEpisodeMainInformationAsync(episodeId);
+
+            // assert
+            response.Should().BeNull();
+        }
+
+        [Fact]
         public async void GetEpisodeByIdAsync_InvalidId_ThrowsArgumentNullException()
         {
             // arrange

--- a/src/TvMaze.Api.Client.Integration.Tests/LookupEndpointIntegrationTests.cs
+++ b/src/TvMaze.Api.Client.Integration.Tests/LookupEndpointIntegrationTests.cs
@@ -27,6 +27,19 @@ namespace TvMaze.Api.Client.Integration.Tests
             // assert
             response.Should().NotBeNull();
         }
+
+        [Fact]
+        public async void GetLookupByTvRageId_ValidParameter_NotFound()
+        {
+            // arrange
+            const int tvRageId = int.MaxValue;
+            
+            // act 
+            var response = await _tvMazeClient.Lookup.GetShowByTvRageId(tvRageId);
+            
+            // assert
+            response.Should().BeNull();
+        }
         
         [Fact]
         public async void GetLookupByTvRageId_InvalidId_ThrowsArgumentNullException()
@@ -53,6 +66,19 @@ namespace TvMaze.Api.Client.Integration.Tests
             // assert
             response.Should().NotBeNull();
         }
+
+        [Fact]
+        public async void GetLookupByTheTvdbId_ValidParameter_NotFound()
+        {
+            // arrange
+            const int theTvdbId = int.MaxValue;
+            
+            // act 
+            var response = await _tvMazeClient.Lookup.GetShowByTheTvdbId(theTvdbId);
+            
+            // assert
+            response.Should().BeNull();
+        }
         
         [Fact]
         public async void GetLookupByTheTvdbId_InvalidId_ThrowsArgumentNullException()
@@ -78,6 +104,19 @@ namespace TvMaze.Api.Client.Integration.Tests
             
             // assert
             response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetLookupByImdbId_ValidParameter_NotFound()
+        {
+            // arrange
+            const string imdbId = "ShouldNotExist";
+            
+            // act 
+            var response = await _tvMazeClient.Lookup.GetShowByImdbId(imdbId);
+            
+            // assert
+            response.Should().BeNull();
         }
         
         [Fact]

--- a/src/TvMaze.Api.Client.Integration.Tests/SearchEndpointIntegrationTests.cs
+++ b/src/TvMaze.Api.Client.Integration.Tests/SearchEndpointIntegrationTests.cs
@@ -24,7 +24,20 @@ namespace TvMaze.Api.Client.Integration.Tests
             var response = await _tvMazeClient.Search.ShowSearchAsync(query);
 
             // assert
-            response.Should().NotBeNull();
+            response.Should().NotBeNull().And.NotBeEmpty();
+        }
+
+        [Fact]
+        public async void ShowSearchAsync_ValidParameter_NoResult()
+        {
+            // arrange
+            const string query = "cars123456";
+
+            // act
+            var response = await _tvMazeClient.Search.ShowSearchAsync(query);
+
+            // assert
+            response.Should().NotBeNull().And.BeEmpty();
         }
 
         [Theory]
@@ -34,6 +47,44 @@ namespace TvMaze.Api.Client.Integration.Tests
         {
             // act
             Func<Task> action = () => _tvMazeClient.Search.ShowSearchAsync(query);
+
+            // assert
+            await action.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async void ShowSingleSearchAsync_ValidParameter_Success()
+        {
+            // arrange
+            const string query = "girls";
+
+            // act
+            var response = await _tvMazeClient.Search.ShowSingleSearchAsync(query);
+
+            // assert
+            response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void ShowSingleSearchAsync_ValidParameter_NoResult()
+        {
+            // arrange
+            const string query = "girls123456";
+
+            // act
+            var response = await _tvMazeClient.Search.ShowSingleSearchAsync(query);
+
+            // assert
+            response.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public async void ShowSingleSearchAsync_InvalidQuery_ThrowsArgumentNullException(string query)
+        {
+            // act
+            Func<Task> action = () => _tvMazeClient.Search.ShowSingleSearchAsync(query);
 
             // assert
             await action.Should().ThrowAsync<ArgumentNullException>();

--- a/src/TvMaze.Api.Client.Integration.Tests/ShowsEndpointIntegrationTests.cs
+++ b/src/TvMaze.Api.Client.Integration.Tests/ShowsEndpointIntegrationTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -16,6 +15,45 @@ namespace TvMaze.Api.Client.Integration.Tests
         }
 
         [Fact]
+        public async void GetShowMainInformationAsync_ValidParameter_Success()
+        {
+            // arrange
+            const int showId = 1;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetShowMainInformationAsync(showId);
+
+            // assert
+            response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetShowMainInformationAsync_ValidParameter_NotFound()
+        {
+            // arrange
+            const int showId = int.MaxValue;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetShowMainInformationAsync(showId);
+
+            // assert
+            response.Should().BeNull();
+        }
+
+        [Fact]
+        public async void GetShowMainInformationAsync_InvalidId_ThrowsArgumentNullException()
+        {
+            // arrange
+            const int showId = 0;
+
+            // act
+            Func<Task> action = () => _tvMazeClient.Shows.GetShowMainInformationAsync(showId);
+
+            // assert
+            await action.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
         public async void GetEpisodeListAsync_ValidParameter_Success()
         {
             // arrange
@@ -29,6 +67,19 @@ namespace TvMaze.Api.Client.Integration.Tests
         }
 
         [Fact]
+        public async void GetEpisodeListAsync_ValidParameter_NotFound()
+        {
+            // arrange
+            const int showId = int.MaxValue;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetShowEpisodeListAsync(showId);
+
+            // assert
+            response.Should().NotBeNull().And.BeEmpty();
+        }
+
+        [Fact]
         public async void GetEpisodeListAsync_InvalidId_ThrowsArgumentNullException()
         {
             // arrange
@@ -36,6 +87,84 @@ namespace TvMaze.Api.Client.Integration.Tests
 
             // act
             Func<Task> action = () => _tvMazeClient.Shows.GetShowEpisodeListAsync(showId);
+
+            // assert
+            await action.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async void GetShowSeasonsAsync_ValidParameter_Success()
+        {
+            // arrange
+            const int showId = 1;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetShowSeasonsAsync(showId);
+
+            // assert
+            response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetShowSeasonsAsync_ValidParameter_NotFound()
+        {
+            // arrange
+            const int showId = int.MaxValue;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetShowSeasonsAsync(showId);
+
+            // assert
+            response.Should().NotBeNull().And.BeEmpty();
+        }
+
+        [Fact]
+        public async void GetShowSeasonsAsync_InvalidId_ThrowsArgumentNullException()
+        {
+            // arrange
+            const int showId = 0;
+
+            // act
+            Func<Task> action = () => _tvMazeClient.Shows.GetShowSeasonsAsync(showId);
+
+            // assert
+            await action.Should().ThrowAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async void GetSeasonEpisodesAsync_ValidParameter_Success()
+        {
+            // arrange
+            const int seasonId = 1;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetSeasonEpisodesAsync(seasonId);
+
+            // assert
+            response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetSeasonEpisodesAsync_ValidParameter_NotFound()
+        {
+            // arrange
+            const int seasonId = int.MaxValue;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetSeasonEpisodesAsync(seasonId);
+
+            // assert
+            response.Should().NotBeNull().And.BeEmpty();
+        }
+
+        [Fact]
+        public async void GetSeasonEpisodesAsync_InvalidId_ThrowsArgumentNullException()
+        {
+            // arrange
+            const int seasonId = 0;
+
+            // act
+            Func<Task> action = () => _tvMazeClient.Shows.GetSeasonEpisodesAsync(seasonId);
 
             // assert
             await action.Should().ThrowAsync<ArgumentNullException>();
@@ -54,6 +183,21 @@ namespace TvMaze.Api.Client.Integration.Tests
 
             // assert
             response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetEpisodeByNumberAsync_ValidParameter_NotFound()
+        {
+            // arrange
+            const int showId = int.MaxValue;
+            const int season = 1;
+            const int number = 1;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetEpisodeByNumberAsync(showId, season, number);
+
+            // assert
+            response.Should().BeNull();
         }
 
         [Theory]
@@ -91,10 +235,10 @@ namespace TvMaze.Api.Client.Integration.Tests
             var date = DateTime.MinValue;
 
             // act
-            Func<Task> action = () => _tvMazeClient.Shows.GetEpisodesByDateAsync(showId, date);
+            var response = await _tvMazeClient.Shows.GetEpisodesByDateAsync(showId, date);
 
             // assert
-            await action.Should().ThrowAsync<HttpRequestException>();
+            response.Should().NotBeNull().And.BeEmpty();
         }
 
         [Fact]
@@ -123,6 +267,19 @@ namespace TvMaze.Api.Client.Integration.Tests
             // assert
             response.Should().NotBeNull();
         }
+
+        [Fact]
+        public async void GetShowCastAsync_ValidParameters_NotFound()
+        {
+            // arrange
+            const int showId = int.MaxValue;
+
+            // act
+            var response = await _tvMazeClient.Shows.GetShowCastAsync(showId);
+
+            // assert
+            response.Should().NotBeNull().And.BeEmpty();
+        }
         
         [Fact]
         public async void GetShowCastAsync_InvalidId_ThrowsArgumentNullException()
@@ -142,6 +299,19 @@ namespace TvMaze.Api.Client.Integration.Tests
         {
             // arrange 
             const int showId = 1;
+            
+            // act
+            var response = await _tvMazeClient.Shows.GetShowCrewAsync(showId);
+
+            // assert
+            response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetShowCrewAsync_ValidParameters_NotFound()
+        {
+            // arrange 
+            const int showId = int.MaxValue;
             
             // act
             var response = await _tvMazeClient.Shows.GetShowCrewAsync(showId);
@@ -174,6 +344,19 @@ namespace TvMaze.Api.Client.Integration.Tests
 
             // assert
             response.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async void GetShowImagesAsync_ValidParameters_NotFound()
+        {
+            // arrange 
+            const int showId = int.MaxValue;
+            
+            // act
+            var response = await _tvMazeClient.Shows.GetShowImagesAsync(showId);
+
+            // assert
+            response.Should().NotBeNull().And.BeEmpty();
         }
         
         [Fact]

--- a/src/TvMaze.Api.Client/Endpoints/Shows/IShowsEndpoint.cs
+++ b/src/TvMaze.Api.Client/Endpoints/Shows/IShowsEndpoint.cs
@@ -14,7 +14,7 @@ namespace TvMaze.Api.Client.Endpoints.Shows
         /// </summary>
         /// <param name="showId">The show ID</param>
         /// <returns>Return all primary information for a given show.</returns>
-        Task<Show> GetShowMainInformation(int showId);
+        Task<Show> GetShowMainInformationAsync(int showId);
 
         /// <summary>
         /// A complete list of episodes for the given show.

--- a/src/TvMaze.Api.Client/Endpoints/Shows/ShowsEndpoint.cs
+++ b/src/TvMaze.Api.Client/Endpoints/Shows/ShowsEndpoint.cs
@@ -16,7 +16,7 @@ namespace TvMaze.Api.Client.Endpoints.Shows
             _httpClient = httpClient;
         }
 
-        public Task<Show> GetShowMainInformation(int showId)
+        public Task<Show> GetShowMainInformationAsync(int showId)
         {
             if (showId <= 0)
             {

--- a/src/TvMaze.Api.Client/Extensions/HttpClientExtensions.cs
+++ b/src/TvMaze.Api.Client/Extensions/HttpClientExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -6,15 +10,43 @@ namespace TvMaze.Api.Client.Extensions
 {
     public static class HttpClientExtensions
     {
-        public static async Task<T> GetAsync<T>(this HttpClient httpClient, string url)
+        public static async Task<T> GetAsync<T>(this HttpClient httpClient, string url, Func<HttpResponseMessage, (bool Handled, T Result)> unsuccessfulResponseHandler = null)
         {
-            var httpResponse = await httpClient.GetAsync(url);
+            using (var httpResponse = await httpClient.GetAsync(url))
+            {
+                if (!httpResponse.IsSuccessStatusCode)
+                {
+                    var handlerResult = unsuccessfulResponseHandler?.Invoke(httpResponse) ??
+                                        DefaultUnsuccessfulResponseHandler<T>(httpResponse);
+                    if (handlerResult.Handled)
+                    {
+                        return handlerResult.Result;
+                    }
 
-            httpResponse.EnsureSuccessStatusCode();
+                    throw new UnexpectedResponseStatusException(httpResponse.StatusCode);
+                }
 
-            var jsonResponse = await httpResponse.Content.ReadAsStringAsync();
+                var jsonResponse = await httpResponse.Content.ReadAsStringAsync();
+                return JsonConvert.DeserializeObject<T>(jsonResponse);
+            }
+        }
 
-            return JsonConvert.DeserializeObject<T>(jsonResponse);
+        private static (bool Handled, T Result) DefaultUnsuccessfulResponseHandler<T>(HttpResponseMessage response)
+        {
+            var resultType = typeof(T);
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.NotFound:
+                    if (resultType.IsConstructedGenericType && resultType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    {
+                        var emptyEnumerable = typeof(Enumerable).GetMethod(nameof(Enumerable.Empty)).MakeGenericMethod(typeof(T).GenericTypeArguments[0]).Invoke(null, null);
+                        return (true, (T)emptyEnumerable);
+                    }
+
+                    return (true, default);
+                default:
+                    return (false, default);
+            }
         }
     }
 }

--- a/src/TvMaze.Api.Client/UnexpectedResponseStatusException.cs
+++ b/src/TvMaze.Api.Client/UnexpectedResponseStatusException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+
+namespace TvMaze.Api.Client
+{
+    public class UnexpectedResponseStatusException : HttpRequestException
+    {
+        public HttpStatusCode StatusCode { get; }
+
+        public UnexpectedResponseStatusException(HttpStatusCode statusCode) : this($"Received unexpected response status \"{statusCode}\".", statusCode)
+        {
+        }
+
+        public UnexpectedResponseStatusException(string message, HttpStatusCode statusCode, Exception innerException = null) : base(message, innerException)
+        {
+            StatusCode = statusCode;
+        }
+    }
+}


### PR DESCRIPTION
Proposal to address #12:

1. Allow it to specify a handler, if a request doesn't return a success status code.
2. Add a default handler, that only handles 404 responses, which returns an empty enumerable if an IEnumerable<> is expected and the default value for all other types (null for objects).
3. If the handler doesn't mark the response as handled, an Exception containing the status code is thrown, which inherits from HttpRequestException to ensure old users of the library still catch it, but also allows it to handle a specific status code if required.