### PR TITLE
Use HTTPS by default as it is the new default inside of TVmaze

### DIFF
--- a/src/TvMaze.Api.Client/TvMazeClient.cs
+++ b/src/TvMaze.Api.Client/TvMazeClient.cs
@@ -10,7 +10,7 @@ namespace TvMaze.Api.Client
 {
     public class TvMazeClient : ITvMazeClient
     {
-        private const string BaseApiUrl = "http://api.tvmaze.com/";
+        private const string BaseApiUrl = "https://api.tvmaze.com/";
 
         public TvMazeClient()
             : this(new HttpClient())


### PR DESCRIPTION
As mentioned in the last changelog by the API developers at https://www.tvmaze.com/threads/4/api-changelog?page=2#64040 TVmaze uses HTTPS by default now. As using HTTPS is a good idea in general we should follow their lead