### PR TITLE
Add handling for rate limiting

### DIFF
--- a/src/TvMaze.Api.Client/Configuration/IRateLimitingStrategy.cs
+++ b/src/TvMaze.Api.Client/Configuration/IRateLimitingStrategy.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading.Tasks;
+using Flurl.Http;
+
+namespace TvMaze.Api.Client.Configuration
+{
+    /// <summary>
+    /// Implementations define, how rate limiting responses by the API should be handled.
+    /// Rate limiting is described at https://www.tvmaze.com/api#rate-limiting.
+    /// </summary>
+    public interface IRateLimitingStrategy
+    {
+        /// <summary>
+        /// Handler for HTTPRequests.
+        /// </summary>
+        /// <param name="action">The function that sends the HTTP Request.</param>
+        /// <returns>The response from the API.</returns>
+        Task<IFlurlResponse> ExecuteAsync(Func<Task<IFlurlResponse>> action);
+    }
+}

--- a/src/TvMaze.Api.Client/Configuration/RateLimitingConstants.cs
+++ b/src/TvMaze.Api.Client/Configuration/RateLimitingConstants.cs
@@ -1,0 +1,13 @@
+﻿namespace TvMaze.Api.Client.Configuration
+{
+    /// <summary>
+    /// Constants useful for all <see cref="IRateLimitingStrategy"/>s.
+    /// </summary>
+    public static class RateLimitingConstants
+    {
+        /// <summary>
+        /// The status code used for rate limiting.
+        /// </summary>
+        public const int StatusCode = 429;
+    }
+}

--- a/src/TvMaze.Api.Client/Configuration/RetryRateLimitingStrategy.cs
+++ b/src/TvMaze.Api.Client/Configuration/RetryRateLimitingStrategy.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using Flurl.Http;
+using Polly;
+
+namespace TvMaze.Api.Client.Configuration
+{
+    /// <summary>
+    /// This implementation will retry the request multiple times, if a rate limit is encountered.
+    /// </summary>
+    public class RetryRateLimitingStrategy : IRateLimitingStrategy
+    {
+        private const int DefaultRetries = 5;
+        private static readonly TimeSpan DefaultRetryInterval = TimeSpan.FromSeconds(3);
+
+        private readonly AsyncPolicy<IFlurlResponse> _policy;
+
+        /// <summary>
+        /// Creates an instance with reasonable default values for the rate limits described by the API.
+        /// </summary>
+        public RetryRateLimitingStrategy()
+            : this(DefaultRetries, DefaultRetryInterval)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance that uses the provided configuration values for retrying.
+        /// </summary>
+        /// <param name="retries"></param>
+        /// <param name="retryInterval"></param>
+        public RetryRateLimitingStrategy(int retries, TimeSpan retryInterval)
+        {
+            _policy = Policy
+                .HandleResult<IFlurlResponse>(response => response.StatusCode == RateLimitingConstants.StatusCode)
+                .WaitAndRetryAsync(retries, i => retryInterval);
+        }
+
+        /// <inheritdoc />
+        public Task<IFlurlResponse> ExecuteAsync(Func<Task<IFlurlResponse>> action)
+        {
+            return _policy.ExecuteAsync(action);
+        }
+    }
+}

--- a/src/TvMaze.Api.Client/Configuration/ThrowExceptionRateLimitingStrategy.cs
+++ b/src/TvMaze.Api.Client/Configuration/ThrowExceptionRateLimitingStrategy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Flurl.Http;
+using TvMaze.Api.Client.Exceptions;
+
+namespace TvMaze.Api.Client.Configuration
+{
+    /// <summary>
+    /// This implementation throws a <see cref="UnexpectedResponseStatusException"/>, if a rate limit is encountered.
+    /// This is the default and should be used, if rate limiting should be handled outside of the library.
+    /// </summary>
+    public class ThrowExceptionRateLimitingStrategy : IRateLimitingStrategy
+    {
+        /// <inheritdoc />
+        public async Task<IFlurlResponse> ExecuteAsync(Func<Task<IFlurlResponse>> action)
+        {
+            var response = await action();
+
+            if (response.StatusCode == RateLimitingConstants.StatusCode)
+            {
+                throw new UnexpectedResponseStatusException("Reached rate limit of the API.", (HttpStatusCode) RateLimitingConstants.StatusCode);
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/TvMaze.Api.Client/TvMaze.Api.Client.csproj
+++ b/src/TvMaze.Api.Client/TvMaze.Api.Client.csproj
@@ -14,5 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="3.0.1" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 </Project>

--- a/src/TvMaze.Api.Client/TvMazeClient.cs
+++ b/src/TvMaze.Api.Client/TvMazeClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using TvMaze.Api.Client.Configuration;
 using TvMaze.Api.Client.Endpoints.Episodes;
 using TvMaze.Api.Client.Endpoints.Lookup;
 using TvMaze.Api.Client.Endpoints.Search;
@@ -13,12 +14,22 @@ namespace TvMaze.Api.Client
         private const string BaseApiUrl = "https://api.tvmaze.com/";
 
         public TvMazeClient()
-            : this(new HttpClient())
+            : this(new HttpClient(), null)
         {
         }
 
-        public TvMazeClient(HttpClient httpClient)
+        public TvMazeClient(HttpClient httpClient) 
+            : this(httpClient, null)
         {
+        }
+
+        public TvMazeClient(HttpClient httpClient, IRateLimitingStrategy rateLimitingStrategy)
+        {
+            if (rateLimitingStrategy == null)
+            {
+                rateLimitingStrategy = new ThrowExceptionRateLimitingStrategy();
+            }
+            
             var flurlClient = new FlurlClient(httpClient);
 
             // Caller didn't provide the base address.
@@ -29,7 +40,7 @@ namespace TvMaze.Api.Client
 
             flurlClient.AllowAnyHttpStatus();
 
-            var tvMazeHttpClient = new TvMazeHttpClient(flurlClient);
+            var tvMazeHttpClient = new TvMazeHttpClient(flurlClient, rateLimitingStrategy);
 
             Search = new SearchEndpoint(tvMazeHttpClient);
             Shows = new ShowsEndpoint(tvMazeHttpClient);

--- a/src/TvMaze.Api.Client/TvMazeHttpClient.cs
+++ b/src/TvMaze.Api.Client/TvMazeHttpClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Flurl.Http;
+using TvMaze.Api.Client.Configuration;
 using TvMaze.Api.Client.Exceptions;
 
 namespace TvMaze.Api.Client
@@ -11,15 +12,17 @@ namespace TvMaze.Api.Client
     public class TvMazeHttpClient
     {
         private readonly FlurlClient _flurlClient;
+        private readonly IRateLimitingStrategy _rateLimitingStrategy;
 
-        public TvMazeHttpClient(FlurlClient flurlClient)
+        public TvMazeHttpClient(FlurlClient flurlClient, IRateLimitingStrategy rateLimitingStrategy)
         {
             _flurlClient = flurlClient;
+            _rateLimitingStrategy = rateLimitingStrategy;
         }
 
         public async Task<T> GetAsync<T>(string url, Func<T> notFoundResponseHandler = null)
         {
-            using (var httpResponse = await _flurlClient.Request(url).GetAsync())
+            using (var httpResponse = await _rateLimitingStrategy.ExecuteAsync(() => _flurlClient.Request(url).GetAsync()))
             {
                 switch (httpResponse.StatusCode)
                 {


### PR DESCRIPTION
The API defines rate limits and will respond with a 429 status code if too many requests are made in a short time (https://www.tvmaze.com/api#rate-limiting). As this is normal behavior of the API it should be possible to define a way to deal with it. For that I introduced the IRateLimitingStrategy interface which allows to define, how the client should deal with this case.

The first implementation just does the same as until now and the normal exception is thrown, but the second implementation uses the very popular Polly library to implement retries wit a waiting interval. As the interface is public, users could inject their own implementations, if they have different needs.

The only thing I don't quite like are the tests, as it can take some time to trigger the rate limiting because cached responses are not counted against the limit but I have currently no idea about how to better test it.